### PR TITLE
fix: correct Mermaid diagram syntax in API_REFERENCE.md

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -15,19 +15,19 @@
 
 Internally, the project consists of a thin **Python wrapper** around a **React / TypeScript** frontend. Python developers only need the `multimodal_chat_input` function; the TypeScript sources are provided for anyone who wants to contribute or embed the widget elsewhere.
 
-````mermaid
+```mermaid
 flowchart LR
-  subgraph Browser (Frontend)
-    Mi[MyComponent.tsx]
-    Hooks[hooks/*]
-    Comps[components/*]
-    Utils[utils/*]
+  subgraph Browser["Browser (Frontend)"]
+    Mi["MyComponent.tsx"]
+    Hooks["hooks/*"]
+    Comps["components/*"]
+    Utils["utils/*"]
   end
-  subgraph Python (Backend)
-    Wrapper[__init__.py → multimodal_chat_input]
+  subgraph Python["Python (Backend)"]
+    Wrapper["__init__.py → multimodal_chat_input"]
   end
   Wrapper <--> Mi
-````
+```
 
 ---
 


### PR DESCRIPTION
Fixes #5

Fixed Mermaid diagram parsing error in `docs/API_REFERENCE.md`:

- Fix code fence from quad backticks to triple backticks
- Quote subgraph labels with special characters
- Quote node labels containing special characters like →

Generated with [Claude Code](https://claude.ai/code)